### PR TITLE
Add missing storedir grommunio archive

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -880,6 +880,7 @@ if [ "$FT_ARCHIVE" == "true" ] ; then
   setconf /etc/grommunio-archive/grommunio-archive.conf mysqlpwd "${ARCHIVE_MYSQL_PASS}" 0
   setconf /etc/grommunio-archive/grommunio-archive.conf mysqldb "${ARCHIVE_MYSQL_DB}" 0
   setconf /etc/grommunio-archive/grommunio-archive.conf listen_addr 0.0.0.0 0
+  setconf /etc/grommunio-archive/grommunio-archive.conf storedir /var/lib/grommunio-archive/store
 
   php /etc/grommunio-archive/sphinx.conf.dist > /etc/sphinx/sphinx.conf
 


### PR DESCRIPTION
Default grommunio-archive file `/etc/grommunio-archive/grommunio-archive.conf.dist` misses a configuration which is needed for various tools used with piler (example: `pilerpurge.py` script).

Has also been discussed on the forum two years ago https://community.grommunio.com/d/187-info-archive-feature/32
